### PR TITLE
feat: add color settings for primary vs secondary badges and headings

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -129,7 +129,8 @@
                         "
                         data-sizes="auto"
                       >
-                      {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
+                      {% capture product-status-class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
+                      {% if product_status != blank %}<div class="product-list-thumb-status {{ product-status-class }}">{{ product_status }}</div>{% endif %}
                     </div>
                     <div class="product-list-thumb-info product-list-thumb-info--{{ theme.product_detail_alignment }}">
                       <div class="product-list-thumb-name">{{ product.name }}</div>

--- a/source/home.html
+++ b/source/home.html
@@ -134,11 +134,13 @@
                     <div class="product-list-thumb-info product-list-thumb-info--{{ theme.product_detail_alignment }}">
                       <div class="product-list-thumb-name">{{ product.name }}</div>
                       <div class="product-list-thumb-price">
-                        {% if product.variable_pricing %}
-                          {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-                        {% else %}
-                          {{ product.default_price | money: theme.money_format }}
-                        {% endif %}
+                        {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                          {% if product.variable_pricing %}
+                            {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                          {% else %}
+                            {{ product.default_price | money: theme.money_format }}
+                          {% endif %}
+                        {% endunless %}
                       </div>
                     </div>
                   </a>

--- a/source/product.html
+++ b/source/product.html
@@ -128,6 +128,13 @@
 
   <section class="product-detail">
     <div class="product-detail__header">
+      {% assign hide_price = false %}
+      {% if theme.show_sold_out_product_prices == false %}
+        {% case product.status %}
+          {% when 'sold-out' %}
+            {% assign hide_price = true %}
+        {% endcase %}
+      {% endif %}
       {% capture product_pricing %}
         {% if product.variable_pricing %}
           {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
@@ -136,7 +143,11 @@
         {% endif %}
       {% endcapture %}
       <h1 class="page-title page-title--left product-detail__title">{{ product.name }}</h1>
-      <div class="product-detail__pricing"><span>{{ product_pricing }}</span> {% if product_status != blank %}<div class="product-detail__status">&mdash; {{ product_status }}</div>{% endif %}</div>
+      <div class="product-detail__pricing">
+        {% unless hide_price %}<span>{{ product_pricing }}</span>{% endunless %}
+        {% if hide_price == false and product_status != blank %}<span class="product-detail__separator">&mdash;</span>{% endif %}
+        {% if product_status != blank %}<div class="product-detail__status">{{ product_status }}</div>{% endif %}
+      </div>
     </div>
     {% if product.status == 'active' %}
       <form method="post" class="product-form {% if theme.show_sold_out_product_options %}show-sold-out{% else %}hide-sold-out{% endif %}" action="/cart" accept-charset="utf8">

--- a/source/products.html
+++ b/source/products.html
@@ -63,11 +63,13 @@
               <div class="product-list-thumb-info product-list-thumb-info--{{ theme.product_detail_alignment }}">
                 <div class="product-list-thumb-name">{{ product.name }}</div>
                 <div class="product-list-thumb-price">
-                  {% if product.variable_pricing %}
-                    {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-                  {% else %}
-                    {{ product.default_price | money: theme.money_format }}
-                  {% endif %}
+                  {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                    {% if product.variable_pricing %}
+                      {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                    {% else %}
+                      {{ product.default_price | money: theme.money_format }}
+                    {% endif %}
+                  {% endunless %}
                 </div>
               </div>
             </a>

--- a/source/products.html
+++ b/source/products.html
@@ -50,15 +50,16 @@
                       {{ product.images[1] | product_image_url | constrain: 320 }} 320w,
                       {{ product.images[1] | product_image_url | constrain: 400 }} 400w,
                       {{ product.images[1] | product_image_url | constrain: 540 }} 540w,
-                      {{ product.images[1] | product_image_url | constrain: 600 }} 600w,
+                    {{ product.images[1] | product_image_url | constrain: 600 }} 600w,
                       {{ product.images[1] | product_image_url | constrain: 800 }} 800w,
                       {{ product.images[1] | product_image_url | constrain: 960 }} 960w
                     "
                     data-sizes="auto"
                   >
                 {% endif %}
-
-                {% if product_status != blank %}<div class="product-list-thumb-status">{{ product_status }}</div>{% endif %}
+                
+                {% capture product-status-class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
+                {% if product_status != blank %}<div class="product-list-thumb-status {{ product-status-class }}">{{ product_status }}</div>{% endif %}
               </div>
               <div class="product-list-thumb-info product-list-thumb-info--{{ theme.product_detail_alignment }}">
                 <div class="product-list-thumb-name">{{ product.name }}</div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -37,6 +37,10 @@
               "secondary_text_color": "#000000",
               "welcome_background_color": "#F9F9F9",
               "welcome_text_color": "#000000",
+              "badge_text_color_primary": "#000000",
+              "badge_background_color_primary": "#FFD700",
+              "badge_text_color_secondary": "#222222",
+              "badge_background_color_secondary": "#B7B7B7",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
             }
@@ -59,6 +63,10 @@
               "secondary_text_color": "#F8F8F8",
               "welcome_background_color": "#242424",
               "welcome_text_color": "#F8F8F8",
+              "badge_text_color_primary": "#222222",
+              "badge_background_color_primary": "#ffc65c",
+              "badge_text_color_secondary": "#222222",
+              "badge_background_color_secondary": "#B7B7B7",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
             }
@@ -76,6 +84,10 @@
               "secondary_text_color": "#0F1B27",
               "welcome_background_color": "#F0EEEE",
               "welcome_text_color": "#0F1B27",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#E64946",
+              "badge_text_color_secondary": "#222222",
+              "badge_background_color_secondary": "#B7B7B7",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
             }
@@ -97,9 +109,13 @@
               "primary_text_color": "#222222",
               "secondary_text_color": "#FFD700",
               "welcome_background_color": "#FFEE54",
-              "welcome_text_color": "#0000FF",
-              "announcement_text_color": "#FFFFFF",
-              "announcement_background_color": "#000000"
+              "welcome_text_color": "#0088FF",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#0088FF",
+              "badge_text_color_secondary": "#222222",
+              "badge_background_color_secondary": "#B7B7B7",
+              "announcement_text_color": "#000000",
+              "announcement_background_color": "#FFEE54"
             }
           },
           {
@@ -112,11 +128,15 @@
               "background_color": "#FFE9F4",
               "primary_heading_text_color": "#243588",
               "primary_text_color": "#243588",
-              "secondary_text_color": "#243588",
+              "secondary_text_color": "#0088FF",
               "welcome_background_color": "#FFF6FB",
               "welcome_text_color": "#243588",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#243588",
+              "badge_text_color_secondary": "#222222",
+              "badge_background_color_secondary": "#B7B7B7",
               "announcement_text_color": "#FFFFFF",
-              "announcement_background_color": "#000000"
+              "announcement_background_color": "#243588"
             }
           }
         ]
@@ -167,13 +187,33 @@
       "default": "#121212"
     },
     {
+      "variable": "badge_text_color_primary",
+      "label": "Badge text (primary)",
+      "default": "#222222"
+    },
+    {
+      "variable": "badge_background_color_primary",
+      "label": "Badge background (primary)",
+      "default": "#FFD700"
+    },
+    {
+      "variable": "badge_text_color_secondary",
+      "label": "Badge text (secondary)",
+      "default": "#222222"
+    },
+    {
+      "variable": "badge_background_color_secondary",
+      "label": "Badge background (secondary)",
+      "default": "#B7B7B7"
+    },
+    {
       "variable": "announcement_text_color",
-      "label": "Announcement Message Text",
+      "label": "Announcement message text",
       "default": "#FFFFFF"
     },
     {
       "variable": "announcement_background_color",
-      "label": "Announcement Message Background",
+      "label": "Announcement message background",
       "default": "#000000"
     }
   ],
@@ -332,7 +372,7 @@
       "label": "Show prices for sold out products",
       "type": "boolean",
       "default": true,
-      "description": "Display prices for sold out products when they are visible",
+      "description": "Show the price of sold out products on product grids and product pages",
       "requires": "inventory"
     },
     {

--- a/source/settings.json
+++ b/source/settings.json
@@ -311,10 +311,18 @@
     },
     {
       "variable": "show_sold_out_product_options",
-      "label": "Show sold out product options",
+      "label": "Show sold out product variants",
       "type": "boolean",
       "default": true,
-      "description": "Shows sold out product options in the Product page dropdowns",
+      "description": "Shows sold out product variants in the Product page dropdowns",
+      "requires": "inventory"
+    },
+    {
+      "variable": "show_sold_out_product_prices",
+      "label": "Show prices for sold out products",
+      "type": "boolean",
+      "default": true,
+      "description": "Display prices for sold out products when they are visible",
       "requires": "inventory"
     },
     {

--- a/source/settings.json
+++ b/source/settings.json
@@ -32,6 +32,7 @@
             },
             "colors": {
               "background_color": "#FFFFFF",
+              "primary_heading_text_color": "#000000",
               "primary_text_color": "#000000",
               "secondary_text_color": "#000000",
               "welcome_background_color": "#F9F9F9",
@@ -53,6 +54,7 @@
             },
             "colors": {
               "background_color": "#141415",
+              "primary_heading_text_color": "#F8F8F8",
               "primary_text_color": "#F8F8F8",
               "secondary_text_color": "#F8F8F8",
               "welcome_background_color": "#242424",
@@ -69,6 +71,7 @@
             },
             "colors": {
               "background_color": "#E9E5E5",
+              "primary_heading_text_color": "#0F1B27",
               "primary_text_color": "#0F1B27",
               "secondary_text_color": "#0F1B27",
               "welcome_background_color": "#F0EEEE",
@@ -90,8 +93,9 @@
             },
             "colors": {
               "background_color": "#FFFFFF",
-              "primary_text_color": "#0000FF",
-              "secondary_text_color": "#0000FF",
+              "primary_heading_text_color": "#0088FF",
+              "primary_text_color": "#222222",
+              "secondary_text_color": "#FFD700",
               "welcome_background_color": "#FFEE54",
               "welcome_text_color": "#0000FF",
               "announcement_text_color": "#FFFFFF",
@@ -106,6 +110,7 @@
             },
             "colors": {
               "background_color": "#FFE9F4",
+              "primary_heading_text_color": "#243588",
               "primary_text_color": "#243588",
               "secondary_text_color": "#243588",
               "welcome_background_color": "#FFF6FB",
@@ -135,6 +140,11 @@
       "variable": "background_color",
       "label": "Background",
       "default": "#FFFFFF"
+    },
+    {
+      "variable": "primary_heading_text_color",
+      "label": "Primary heading text",
+      "default": "#000000"
     },
     {
       "variable": "primary_text_color",

--- a/source/stylesheets/_variables.sass
+++ b/source/stylesheets/_variables.sass
@@ -6,6 +6,7 @@ $break-extra-small: 500px
 
 \:root
   --background-color: #{'{{ theme.background_color }}'}
+  --primary-heading-text-color: #{'{{ theme.primary_heading_text_color }}'}
   --primary-text-color: #{'{{ theme.primary_text_color }}'}
   --secondary-text-color: #{'{{ theme.secondary_text_color }}'}
   --border-color: #{'{{ theme.primary_text_color }}'}

--- a/source/stylesheets/_variables.sass
+++ b/source/stylesheets/_variables.sass
@@ -18,8 +18,10 @@ $break-extra-small: 500px
   --button-background-color: var(--primary-text-color)
   --button-hover-background-color: #{'rgba(var(--primary-text-color-rgb), .8)'}
 
-  --product-status-background-color: #{"{{ theme.announcement_background_color }}"}
-  --product-status-text-color: #{"{{ theme.announcement_text_color }}"}
+  --badge-text-color-primary: #{"{{ theme.badge_text_color_primary }}"}
+  --badge-background-color-primary: #{"{{ theme.badge_background_color_primary }}"}
+  --badge-text-color-secondary: #{"{{ theme.badge_text_color_secondary }}"}
+  --badge-background-color-secondary: #{"{{ theme.badge_background_color_secondary }}"}
 
   --announcement-background-color: #{"{{ theme.announcement_background_color }}"}
   --announcement-text-color: #{"{{ theme.announcement_text_color }}"}

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -347,6 +347,9 @@ header
       a
         text-decoration: underline
 
+  .page-title, .page-header 
+    color: var(--primary-heading-text-color)
+
   &.page-contact
     .wrapper
       max-width: calc(760px + var(--padding-size))

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -72,13 +72,15 @@
     font-size: .875em
     line-height: normal
     display: inline-block
-    margin-left: 8px
 
   &__pricing
     display: flex
     align-items: center
     font-size: 1.5em
     color: var(--primary-text-color)
+
+  &__separator
+    margin: 0 8px
 
   &__description
     p

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -68,6 +68,11 @@
     flex-direction: column
     align-items: flex-start
 
+  &__title
+    color: var(--primary-heading-text-color)
+    line-height: 1.2
+    padding-bottom: 10px
+
   &__status
     font-size: .875em
     line-height: normal
@@ -105,6 +110,7 @@
       text-decoration: underline
 
   .page-title
+    color: var(--primary-heading-text-color)
     margin-bottom: 0
     text-align: left
 

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -79,9 +79,15 @@ a.product-list-link
   line-height: normal
   display: inline-block
   padding: 6px 8px
-  color: var(--product-status-text-color)
-  background: var(--product-status-background-color)
   border-radius: var(--border-radius-sm)
+
+  &.status-primary
+    background: var(--badge-background-color-primary)
+    color: var(--badge-text-color-primary)
+
+  &.status-secondary
+    background: var(--badge-background-color-secondary)
+    color: var(--badge-text-color-secondary)
 
 .product-list-thumb-info
   line-height: normal


### PR DESCRIPTION
Primary vs secondary badge colors so we can emphasize on sale separate from coming soon or out of stock.

![image](https://github.com/user-attachments/assets/08909a0c-ff0d-424e-bb2d-724e7e9a199e)


Also adds setting for page headings to allow some styles to have more pizzazz. E.g. styles can be set to do this:

![image](https://github.com/user-attachments/assets/61bc80ac-8e0b-4bda-b336-34359ecd0000)


