### PR TITLE
feat: allow contact and maintenance mode msg to be longer

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -469,12 +469,14 @@
       "variable": "maintenance_message",
       "label": "Maintenance mode message",
       "type": "text",
+      "max_length": 2048,
       "description": "A message visitors see when your shop is in Maintenance Mode",
       "default": "We're working on our shop right now.<br /><br />Please check back soon."
     },
     {
       "variable": "announcement_message_text",
       "label": "Announcement text",
+      "max_length": 500,
       "type": "text",
       "description": "Displays an announcement message on the top of every page"
     },


### PR DESCRIPTION
Uses the `max_length` prop to allow contact and maintenance messages to be longer. Allows for flexibility with HTML tags to be present.